### PR TITLE
test: use unittest.mock when available

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 coverage
 codecov
-mock
+mock; python_version < '3.3'
 nose
 setuptools-scm

--- a/test/test_unix_connect.py
+++ b/test/test_unix_connect.py
@@ -6,7 +6,10 @@ import socket
 import sys
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from Xlib.support import unix_connect
 from Xlib.error import DisplayConnectionError, DisplayNameError


### PR DESCRIPTION
The mock module is no longer required in Python 3.3 as unittest now has a mock module. This patch keeps older versions of Python compatible.