### PR TITLE
randr: inherit XError in error classes

### DIFF
--- a/Xlib/ext/randr.py
+++ b/Xlib/ext/randr.py
@@ -36,6 +36,7 @@ http://www.x.org/releases/X11R7.5/doc/randrproto/randrproto.txt
 
 from Xlib import X
 from Xlib.protocol import rq
+from Xlib.error import XError
 
 extname = 'RANDR'
 
@@ -123,11 +124,11 @@ BadRRCrtc                   = 1
 BadRRMode                   = 2
 
 # Error classes #
-class BadRROutputError(Exception): pass
+class BadRROutputError(XError): pass
 
-class BadRRCrtcError(Exception): pass
+class BadRRCrtcError(XError): pass
 
-class BadRRModeError(Exception): pass
+class BadRRModeError(XError): pass
 
 # Data Structures #
 


### PR DESCRIPTION
Commit c87624dd6 ('Add Randr error classes and register them during init') introduces three new error classes to xrandr, but makes them inherit from Exception.

Let all error classes in randr inherit from Xerror, like all other code expects.

Fixes the traceback

```
...
  File "/tmp/python-env/lib/python3.8/site-packages/Xlib/display.py", line 182, in sync
    self.get_pointer_control()
  File "/tmp/python-env/lib/python3.8/site-packages/Xlib/display.py", line 833, in get_pointer_control
    return request.GetPointerControl(display = self.display)
  File "/tmp/python-env/lib/python3.8/site-packages/Xlib/protocol/rq.py", line 1369, in __init__
    self.reply()
  File "/tmp/python-env/lib/python3.8/site-packages/Xlib/protocol/rq.py", line 1381, in reply
    self._display.send_and_recv(request = self._serial)
  File "/tmp/python-env/lib/python3.8/site-packages/Xlib/protocol/display.py", line 612, in send_and_recv
    gotreq = self.parse_response(request)
  File "/tmp/python-env/lib/python3.8/site-packages/Xlib/protocol/display.py", line 719, in parse_response
    gotreq = self.parse_error_response(request) or gotreq
  File "/tmp/python-env/lib/python3.8/site-packages/Xlib/protocol/display.py", line 745, in parse_error_response
    req = self.get_waiting_request(e.sequence_number)
AttributeError: 'BadRRModeError' object has no attribute 'sequence_number'
```

fixes #241