### PR TITLE
remove legacy check for pre 2016 era setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,6 @@
 # Distutils script for python-xlib
 
-from pkg_resources import parse_requirements
-from setuptools import (__version__ as setuptools_version, setup)
-
-
-# Check setuptools is recent enough to support `setup.cfg`.
-setuptools_require = next(parse_requirements('setuptools>=30.3.0'))
-assert setuptools_version in setuptools_require, '{} is required'.format(setuptools_require)
-
+from setuptools import setup
 
 setup(
     install_requires=['six>=1.10.0'],


### PR DESCRIPTION
setuptools no longer has `pkg_resources` and just generally we do not need to do the check anymore for version 30+, so just need to import setup here. 